### PR TITLE
Add mTLS cert role logging and AWS cert inspection tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A simple NextJS web application showing the perseus authentication and authorisa
 - [Development with docker](#development-with-docker)
 - [Message Delivery Endpoint](#message-delivery-endpoint)
 - [Certificates and keys](#certificates-and-keys)
+  - [Uploading certificates to AWS Secrets Manager](#uploading-certificates-to-aws-secrets-manager)
+  - [Inspecting a stored certificate](#inspecting-a-stored-certificate)
   - [Using KMS keys](#using-kms-keys)
 - [Using the CLI](#using-the-cli)
   - [Configuration](#configuration)
@@ -106,6 +108,35 @@ The client key and bundle are used for mutual TLS.
 For local development, the app uses local files. In production, these are stored in AWS Secrets Manager.
 
 For a guide to creating certificates using the directory see [Generate a testing key and certificate](docs/generate_certificates.md)
+
+### Uploading certificates to AWS Secrets Manager
+
+In deployed environments the key and bundle are read from the Secrets Manager secret `<env>/perseus-demo-cap/mtls-key-bundle`. Use `scripts/create_secrets.sh` to create or update it (requires AWS credentials for the target account).
+
+The `mtlsBundle` must be the **client (leaf) certificate concatenated with the intermediate CA certificate** for the directory client issuer — leaf first, intermediate second. A leaf-only bundle will fail the mTLS handshake. Build it with:
+
+```bash
+cat client-cert.pem intermediate.pem > client-bundle.pem
+```
+
+Then upload, passing the key and bundle paths (the env defaults to `dev`):
+
+```bash
+cd scripts
+./create_secrets.sh dev --key ../path/to/client-key.pem --bundle ../path/to/client-bundle.pem
+```
+
+Run `./create_secrets.sh --help` for all options. If `--key`/`--bundle` are omitted it falls back to the local `../certs/cap-demo-certs/` paths.
+
+### Inspecting a stored certificate
+
+To verify what is actually stored in Secrets Manager — subject, validity, and the decoded IB1 roles/member/application — run:
+
+```bash
+npm run check-cert -- dev
+```
+
+This decodes each certificate in the bundle and flags whether the `carbon-accounting-provider` role is present and which trust-framework registry host it is scoped to (a role scoped to the wrong environment, e.g. `sandbox` instead of `development`, causes a `401 ... does not include role` at token exchange).
 
 ### Using KMS keys
 

--- a/lib/clientConfig.ts
+++ b/lib/clientConfig.ts
@@ -1,10 +1,12 @@
 import * as undici from 'undici'
 import { readFileSync } from 'fs'
 import { X509Certificate } from 'crypto'
+import * as x509 from '@peculiar/x509'
 import {
   GetSecretValueCommand,
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager'
+import { decodeApplication, decodeMember, decodeRoles } from './ib1Cert'
 
 export interface ICertificates {
   mtlsKey: string
@@ -195,6 +197,33 @@ export const createCustomFetch = async (config?: IClientConfig) => {
       const subjectCN = cnMatch ? cnMatch[1] : 'unknown'
       console.log(`[mTLS] Client certificate CN: ${subjectCN}`)
       console.log(`[mTLS] Bundle contains ${certMatches.length} certificate(s)`)
+
+      // Decode the IB1 identity fields so role-related auth failures (e.g. a
+      // 401 "Client certificate does not include role ...") are diagnosable
+      // from the logs. Each is guarded independently so a missing extension
+      // logs a warning rather than throwing inside the request path.
+      const ib1Cert = new x509.X509Certificate(certMatches[0])
+      try {
+        console.log(
+          `[mTLS] Client certificate roles: ${JSON.stringify(decodeRoles(ib1Cert))}`,
+        )
+      } catch (e) {
+        console.warn(`[mTLS] Could not decode certificate roles: ${e}`)
+      }
+      try {
+        console.log(
+          `[mTLS] Client certificate member: ${decodeMember(ib1Cert)}`,
+        )
+      } catch (e) {
+        console.warn(`[mTLS] Could not decode certificate member: ${e}`)
+      }
+      try {
+        console.log(
+          `[mTLS] Client certificate application: ${decodeApplication(ib1Cert)}`,
+        )
+      } catch (e) {
+        console.warn(`[mTLS] Could not decode certificate application: ${e}`)
+      }
     } catch (e) {
       console.warn(`[mTLS] Could not parse client certificate: ${e}`)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "prettier": "^3.8.3",
         "tailwindcss": "^4.3.0",
+        "tsx": "^4.19.3",
         "typescript": "^5.9.3"
       }
     },
@@ -658,6 +659,448 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2852,6 +3295,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3570,6 +4055,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6100,6 +6600,25 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "ts-lint": "tsc --noEmit --incremental",
-    "start": "next start"
+    "start": "next start",
+    "check-cert": "tsx scripts/check-cert.ts"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1049.0",
@@ -37,6 +38,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.3.0",
+    "tsx": "^4.19.3",
     "typescript": "^5.9.3"
   }
 }

--- a/scripts/check-cert.ts
+++ b/scripts/check-cert.ts
@@ -1,0 +1,141 @@
+/**
+ * Inspect the mTLS client certificate stored in AWS Secrets Manager and print
+ * its IB1 identity fields (application, member, roles) plus basic validity.
+ *
+ * Usage:
+ *   npm run check-cert -- <env>      (env: dev | preprod | prod, default: dev)
+ *   npx tsx scripts/check-cert.ts dev
+ *
+ * Requires ambient AWS credentials for the account holding the secret
+ * `<env>/perseus-demo-cap/mtls-key-bundle` in eu-west-2.
+ */
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager'
+import * as x509 from '@peculiar/x509'
+import { decodeApplication, decodeMember, decodeRoles } from '../lib/ib1Cert'
+
+const REGION = 'eu-west-2'
+const EXPECTED_ROLE_SUFFIX = '/role/carbon-accounting-provider'
+
+const env = process.argv[2] ?? 'dev'
+const secretName = `${env}/perseus-demo-cap/mtls-key-bundle`
+
+const tryDecode = (label: string, fn: () => string | string[]) => {
+  try {
+    const value = fn()
+    console.log(`  ${label}:`, value)
+    return value
+  } catch (e) {
+    console.log(`  ${label}: ⚠ not present (${(e as Error).message})`)
+    return undefined
+  }
+}
+
+const main = async () => {
+  console.log(
+    `Fetching secret "${secretName}" from Secrets Manager (${REGION})`,
+  )
+
+  const client = new SecretsManagerClient({ region: REGION })
+
+  let secretString: string | undefined
+  try {
+    const data = await client.send(
+      new GetSecretValueCommand({ SecretId: secretName }),
+    )
+    secretString = data.SecretString
+  } catch (e) {
+    console.error(`\n✖ Failed to read secret "${secretName}":`)
+    console.error(`  ${(e as Error).message}`)
+    console.error(
+      '\n  Check that you have AWS credentials for the right account ' +
+        '(e.g. `aws sso login`) and that the env name is correct.',
+    )
+    process.exit(2)
+  }
+
+  if (!secretString) {
+    console.error('✖ Secret has no SecretString value')
+    process.exit(2)
+  }
+
+  const secret = JSON.parse(secretString)
+  const mtlsBundle: string | undefined = secret.mtlsBundle
+  if (!mtlsBundle) {
+    console.error('✖ Secret JSON is missing "mtlsBundle"')
+    process.exit(2)
+  }
+
+  const certMatches = mtlsBundle.match(
+    /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g,
+  )
+  if (!certMatches || certMatches.length === 0) {
+    console.error('✖ No certificates found in mtlsBundle')
+    process.exit(2)
+  }
+
+  console.log(`\nBundle contains ${certMatches.length} certificate(s)\n`)
+
+  let roles: string[] | undefined
+
+  certMatches.forEach((pem, index) => {
+    const cert = new x509.X509Certificate(pem)
+    const role = index === 0 ? ' (leaf / client certificate)' : ''
+    console.log(`Certificate #${index}${role}`)
+    console.log(`  Subject:   ${cert.subject}`)
+    console.log(`  Issuer:    ${cert.issuer}`)
+    console.log(`  Serial:    ${cert.serialNumber}`)
+    console.log(`  Not before: ${cert.notBefore.toISOString()}`)
+    console.log(`  Not after:  ${cert.notAfter.toISOString()}`)
+
+    if (index === 0) {
+      tryDecode('Application', () => decodeApplication(cert))
+      tryDecode('Member', () => decodeMember(cert))
+      roles = tryDecode('Roles', () => decodeRoles(cert)) as
+        | string[]
+        | undefined
+    }
+    console.log()
+  })
+
+  const now = new Date()
+  const leaf = new x509.X509Certificate(certMatches[0])
+  if (now < leaf.notBefore || now > leaf.notAfter)
+    console.log('⚠ Leaf certificate is NOT currently valid (date out of range)')
+
+  console.log('Summary')
+  if (!roles || roles.length === 0) {
+    console.log(
+      '  ✖ Leaf certificate has no roles extension (OID 1.3.6.1.4.1.62329.1.1)',
+    )
+    process.exit(1)
+  }
+
+  console.log('  Roles on certificate:')
+  for (const r of roles) console.log(`    - ${r}`)
+
+  const caRoles = roles.filter(r => r.endsWith(EXPECTED_ROLE_SUFFIX))
+  if (caRoles.length === 0) {
+    console.log('  ✖ No carbon-accounting-provider role present')
+    process.exit(1)
+  }
+
+  // The role string is scoped to a specific trust-framework registry host
+  // (e.g. registry.core.sandbox.trust.ib1.org vs ...development...). A cert
+  // with the right role name but the wrong registry host still 401s with
+  // "Client certificate does not include role ...", so surface the host(s).
+  const registryHosts = Array.from(new Set(caRoles.map(r => new URL(r).host)))
+  console.log('  ✔ carbon-accounting-provider role present')
+  console.log(`    scoped to registry host(s): ${registryHosts.join(', ')}`)
+  console.log(
+    '    NB: this host must match the trust framework the target server runs ' +
+      'on\n    (a sandbox-scoped role will be rejected by a development server).',
+  )
+}
+
+main().catch(e => {
+  console.error('Unexpected error:', e)
+  process.exit(2)
+})

--- a/scripts/create_secrets.sh
+++ b/scripts/create_secrets.sh
@@ -1,11 +1,54 @@
 #!/bin/bash
-# Allow ENV to be provided as an argument, default to 'dev'
-ENV="${1:-dev}"
+# Upload mTLS key + certificate bundle to AWS Secrets Manager.
+#
+# Usage:
+#   ./create_secrets.sh [ENV] [-k|--key KEY_PATH] [-b|--bundle BUNDLE_PATH]
+#
+#   ENV            Environment / secret prefix (default: dev)
+#   -k, --key      Path to the mTLS private key PEM
+#                  (default: ../certs/cap-demo-certs/cap-demo-key.pem)
+#   -b, --bundle   Path to the mTLS certificate bundle PEM
+#                  (default: ../certs/cap-demo-certs/cap-demo-bundle.pem)
+#
+# Examples:
+#   ./create_secrets.sh dev
+#   ./create_secrets.sh dev --key ./dev-key.pem --bundle ./dev-bundle.pem
 
-# Define file paths for your local certificate files
+usage() {
+  sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+# Defaults
+ENV="dev"
 MTLS_KEY_PATH="../certs/cap-demo-certs/cap-demo-key.pem"
 MTLS_BUNDLE_PATH="../certs/cap-demo-certs/cap-demo-bundle.pem"
 # SERVER_CA_PATH="../certs/directory-server-certificates/bundle.pem"
+
+# Parse arguments: ENV is an optional positional, key/bundle are flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -k|--key)
+      MTLS_KEY_PATH="$2"
+      shift 2
+      ;;
+    -b|--bundle)
+      MTLS_BUNDLE_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage 0
+      ;;
+    -*)
+      echo "Error: unknown option '$1'" >&2
+      usage 1
+      ;;
+    *)
+      ENV="$1"
+      shift
+      ;;
+  esac
+done
 
 # Define secret name and description
 SECRET_NAME="${ENV}/perseus-demo-cap/mtls-key-bundle"


### PR DESCRIPTION
## Summary

Makes role-related mTLS authentication failures diagnosable. The dev web flow was failing token exchange with `401 - Client certificate does not include role .../carbon-accounting-provider`, but the logs only showed the certificate CN, so the cause (a certificate scoped to the wrong trust-framework registry) was opaque.

## Changes

- **`lib/clientConfig.ts`** — `createCustomFetch` now logs the decoded **roles**, **member** and **application** next to the existing `[mTLS] Client certificate CN:` line, reusing the existing `decodeRoles`/`decodeMember`/`decodeApplication` helpers in `lib/ib1Cert.ts`. Each is guarded independently so a missing extension warns rather than throwing in the request path.
- **`scripts/check-cert.ts`** (new) — `npm run check-cert -- <env>` fetches `<env>/perseus-demo-cap/mtls-key-bundle` from Secrets Manager, decodes each cert in the bundle, and flags whether the `carbon-accounting-provider` role is present and **which registry host it is scoped to** (a `sandbox`-scoped role on a `development` server causes the 401). Adds `tsx` as a devDependency.
- **`scripts/create_secrets.sh`** — accepts `--key`/`--bundle` paths from the CLI (previously hardcoded), with `--help` and the prior local paths as defaults.
- **`README.md`** — documents uploading to Secrets Manager (including that the bundle must be **leaf + intermediate concatenated**) and inspecting a stored certificate.

## Context

Root cause of the dev 401 was a sandbox-scoped role URI in the directory database; the cert has since been re-issued with the correct development-scoped role and re-uploaded. This PR is the tooling/logging to diagnose and prevent recurrence. Note: the running app caches the secret in-memory (`getClientConfigPromise` singleton), so picking up a rotated cert requires a process restart/redeploy.

## Testing

- `npm run ts-lint`, `npm run lint`, `npm run format` (prettier) all pass.
- `npm run check-cert -- dev` verified end-to-end against the live secret (correct development-scoped role, 2-cert bundle).